### PR TITLE
F#449 catalog not required when presto

### DIFF
--- a/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/connection/jdbc/OracleConnection.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/connection/jdbc/OracleConnection.java
@@ -15,11 +15,9 @@
 package app.metatron.discovery.domain.datasource.connection.jdbc;
 
 import com.fasterxml.jackson.annotation.JsonTypeName;
-
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.data.domain.Pageable;
 
-import javax.persistence.Column;
 import javax.persistence.DiscriminatorValue;
 import javax.persistence.Entity;
 import javax.validation.constraints.NotNull;
@@ -37,7 +35,7 @@ public class OracleConnection extends JdbcDataConnection {
   private static final String[] DESCRIBE_PROP = {};
 
   @NotNull
-  @Column(name = "dc_sid")
+//  @Column(name = "dc_sid")
   String sid;
 
   public OracleConnection() {

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/connection/jdbc/OracleConnection.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/connection/jdbc/OracleConnection.java
@@ -18,9 +18,9 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.data.domain.Pageable;
 
+import javax.persistence.Column;
 import javax.persistence.DiscriminatorValue;
 import javax.persistence.Entity;
-import javax.validation.constraints.NotNull;
 
 /**
  * Created by kyungtaak on 2016. 6. 16..
@@ -34,8 +34,8 @@ public class OracleConnection extends JdbcDataConnection {
   private static final String ORCLE_DEFAULT_OPTIONS = "";
   private static final String[] DESCRIBE_PROP = {};
 
-  @NotNull
-//  @Column(name = "dc_sid")
+//  @NotNull
+  @Column(name = "dc_sid")
   String sid;
 
   public OracleConnection() {

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/connection/jdbc/PrestoConnection.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/connection/jdbc/PrestoConnection.java
@@ -15,14 +15,12 @@
 package app.metatron.discovery.domain.datasource.connection.jdbc;
 
 import com.fasterxml.jackson.annotation.JsonTypeName;
-
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.data.domain.Pageable;
 
 import javax.persistence.Column;
 import javax.persistence.DiscriminatorValue;
 import javax.persistence.Entity;
-import javax.validation.constraints.NotNull;
 
 /**
  * Created by kyungtaak on 2016. 10. 5..
@@ -37,7 +35,6 @@ public class PrestoConnection extends HiveMetastoreConnection {
   private static final String[] DESCRIBE_PROP = {};
 
   @Column(name = "dc_catalog")
-  @NotNull
   String catalog;
 
   @Override

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/connection/jdbc/PrestoConnection.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/connection/jdbc/PrestoConnection.java
@@ -34,6 +34,7 @@ public class PrestoConnection extends HiveMetastoreConnection {
   private static final String PRESTO_DEFAULT_OPTIONS = "";
   private static final String[] DESCRIBE_PROP = {};
 
+//  @NotNull
   @Column(name = "dc_catalog")
   String catalog;
 

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/connection/jdbc/TiberoConnection.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/connection/jdbc/TiberoConnection.java
@@ -18,9 +18,9 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.data.domain.Pageable;
 
+import javax.persistence.Column;
 import javax.persistence.DiscriminatorValue;
 import javax.persistence.Entity;
-import javax.validation.constraints.NotNull;
 
 @Entity
 @DiscriminatorValue("TIBERO")
@@ -30,8 +30,8 @@ public class TiberoConnection extends JdbcDataConnection {
   private static final String TIBERO_URL_PREFIX = "jdbc:tibero:thin:@";
   private static final String[] DESCRIBE_PROP = {};
 
-  @NotNull
-//  @Column(name = "dc_sid")
+//  @NotNull
+  @Column(name = "dc_sid")
   String sid;
 
   public TiberoConnection() {

--- a/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/connection/jdbc/TiberoConnection.java
+++ b/discovery-server/src/main/java/app/metatron/discovery/domain/datasource/connection/jdbc/TiberoConnection.java
@@ -15,11 +15,9 @@
 package app.metatron.discovery.domain.datasource.connection.jdbc;
 
 import com.fasterxml.jackson.annotation.JsonTypeName;
-
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.data.domain.Pageable;
 
-import javax.persistence.Column;
 import javax.persistence.DiscriminatorValue;
 import javax.persistence.Entity;
 import javax.validation.constraints.NotNull;
@@ -33,7 +31,7 @@ public class TiberoConnection extends JdbcDataConnection {
   private static final String[] DESCRIBE_PROP = {};
 
   @NotNull
-  @Column(name = "dc_sid")
+//  @Column(name = "dc_sid")
   String sid;
 
   public TiberoConnection() {


### PR DESCRIPTION
### Description
removed @NotNull annotation for URL only option (Presto, Oracle, Tibero)

**Related Issue** : 
#449

### How Has This Been Tested?
1. MANAGEMENT > Data storage > Data Connection
2. Click 'Create new Data Connection'
3. choose PRESTO
4. choose 'URL only'
5. input url : 'jdbc:presto://localhost:8080/hive'
6. input user : hive, password : hive
7. Click 'Save'
8. successfully saved.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project. _it will be added soon_
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document. _it will be added soon_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### Additional Context<!-- if not appropriate, remove this topic. -->
